### PR TITLE
Add user-agent argument to WinRM client for customization

### DIFF
--- a/evil_winrm_py/evil_winrm_py.py
+++ b/evil_winrm_py/evil_winrm_py.py
@@ -866,6 +866,11 @@ def main():
         help="local path to certificate PEM file",
     )
     parser.add_argument("--uri", default="wsman", help="wsman URI (default: /wsman)")
+    parser.add_argument(
+        "--user-agent",
+        default="Microsoft WinRM Client",
+        help='user agent for the WinRM client (default: "Microsoft WinRM Client")',
+    )
     parser.add_argument("--ssl", action="store_true", help="use ssl")
     parser.add_argument(
         "--port", type=int, default=5985, help="remote host port (default 5985)"
@@ -988,6 +993,7 @@ def main():
             negotiate_hostname_override=args.spn_hostname,
             certificate_key_pem=args.priv_key_pem,
             certificate_pem=args.cert_pem,
+            user_agent=args.user_agent,
         ) as wsman:
             interactive_shell(wsman)
     except WinRMTransportError as wte:


### PR DESCRIPTION
This pull request adds support for customizing the user agent in the WinRM client by introducing a new command-line argument and passing it to the WinRM transport layer.

### New feature: User agent customization
* Added a `--user-agent` argument to the command-line interface, allowing users to specify a custom user agent for the WinRM client. The default is set to `"Microsoft WinRM Client"`. (`evil_winrm_py/evil_winrm_py.py`, [evil_winrm_py/evil_winrm_py.pyR869-R873](diffhunk://#diff-bf104e58976c88a3dc55cd65710696f2a3c04be1ad9f54665772cefa521eb5eeR869-R873))
* Updated the `wsman` initialization to include the `user_agent` parameter, passing the value provided via the new `--user-agent` argument. (`evil_winrm_py/evil_winrm_py.py`, [evil_winrm_py/evil_winrm_py.pyR996](diffhunk://#diff-bf104e58976c88a3dc55cd65710696f2a3c04be1ad9f54665772cefa521eb5eeR996))

### Depends on
* https://github.com/jborean93/pypsrp/pull/202