### PR TITLE
Inline obfuscation

### DIFF
--- a/evil_winrm_py/evil_winrm_py.py
+++ b/evil_winrm_py/evil_winrm_py.py
@@ -1291,7 +1291,7 @@ def interactive_shell(r_pool: RunspacePool) -> None:
                 try:
                     ps = PowerShell(r_pool)
                     ps.add_cmdlet("Invoke-Expression").add_parameter(
-                        "Command", ps_obfuscate(command)
+                        "Command", ps_obfuscate(command) if OBFUSCATION_ENABLED else command
                     )
                     ps.add_cmdlet("Out-String").add_parameter("Stream")
                     ps.begin_invoke()

--- a/evil_winrm_py/evil_winrm_py.py
+++ b/evil_winrm_py/evil_winrm_py.py
@@ -1070,6 +1070,13 @@ def run_exe(r_pool: RunspacePool, local_path: str, args: str = "") -> None:
             ps.stop()
 
 
+def ps_obfuscate(command: str) -> str:
+    """Obfuscates a PowerShell command using various techniques."""
+    obfuscated = ""
+    # use technique such as random int, random casing, variable randomization, random chars, etc.
+    return command
+
+
 def interactive_shell(r_pool: RunspacePool) -> None:
     """Runs the interactive pseudo-shell."""
     log.info("Starting interactive PowerShell session...")
@@ -1283,7 +1290,9 @@ def interactive_shell(r_pool: RunspacePool) -> None:
             else:
                 try:
                     ps = PowerShell(r_pool)
-                    ps.add_cmdlet("Invoke-Expression").add_parameter("Command", command)
+                    ps.add_cmdlet("Invoke-Expression").add_parameter(
+                        "Command", ps_obfuscate(command)
+                    )
                     ps.add_cmdlet("Out-String").add_parameter("Stream")
                     ps.begin_invoke()
                     log.info("Executing command: {}".format(command))

--- a/evil_winrm_py/evil_winrm_py.py
+++ b/evil_winrm_py/evil_winrm_py.py
@@ -83,6 +83,10 @@ MENU_COMMANDS = {
         "syntax": "runexe <local_path>.exe [args]",
         "info": "Upload and execute (in-memory) a local EXE on the remote host",
     },
+    "obf": {
+        "syntax": "obf, obs",
+        "info": "Toggle command obfuscation on/off",
+    },
     "menu": {
         "syntax": "menu",
         "info": "Show this menu",
@@ -97,6 +101,7 @@ MENU_COMMANDS = {
     },
 }
 COMMAND_SUGGESTIONS = []
+OBFUSCATION_ENABLED = False
 
 # --- Colors ---
 # ANSI escape codes for colored output
@@ -157,8 +162,11 @@ def get_prompt(r_pool: RunspacePool) -> str:
     output, streams, had_errors = run_ps_cmd(
         r_pool, "$pwd.Path"
     )  # Get current working directory
+    OBS = ""
+    if OBFUSCATION_ENABLED:
+        OBS = f"{YELLOW}{BOLD} (#$!){RESET}"
     if not had_errors:
-        return f"{RED}evil-winrm-py{RESET} {YELLOW}{BOLD}PS{RESET} {output}> "
+        return f"{RED}evil-winrm-py{RESET} {YELLOW}{BOLD}PS{RESET}{OBS} {output}> "
     return "PS ?> "  # Fallback prompt
 
 
@@ -1266,6 +1274,11 @@ def interactive_shell(r_pool: RunspacePool) -> None:
                 args = " ".join(command_parts[2:]) if len(command_parts) > 2 else ""
 
                 run_exe(r_pool, local_path, args)
+                continue
+            elif command_lower in ["obf", "obs"]:
+                global OBFUSCATION_ENABLED
+                OBFUSCATION_ENABLED = not OBFUSCATION_ENABLED
+                log.info("Command obfuscation togged")
                 continue
             else:
                 try:

--- a/evil_winrm_py/evil_winrm_py.py
+++ b/evil_winrm_py/evil_winrm_py.py
@@ -1285,7 +1285,7 @@ def interactive_shell(r_pool: RunspacePool) -> None:
             elif command_lower in ["obf", "obs"]:
                 global OBFUSCATION_ENABLED
                 OBFUSCATION_ENABLED = not OBFUSCATION_ENABLED
-                log.info("Command obfuscation togged")
+                log.info("Command obfuscation toggled")
                 continue
             else:
                 try:


### PR DESCRIPTION
This pull request adds support for command obfuscation to the interactive PowerShell shell in `evil_winrm_py.py`. Users can now toggle obfuscation on and off using the new `obf`/`obs` command, and the shell prompt visually indicates when obfuscation is enabled. The groundwork for obfuscating PowerShell commands is included, though the actual obfuscation logic is yet to be implemented.

**Command obfuscation feature:**

* Added a new `obf`/`obs` command to the shell menu, allowing users to toggle command obfuscation on or off.
* Introduced the global `OBFUSCATION_ENABLED` flag to track obfuscation state.
* Updated the shell prompt to show a visual indicator when obfuscation is enabled.
* Added a stub for the `ps_obfuscate` function, which will eventually obfuscate PowerShell commands before execution.
* Modified the command execution flow to pass all commands through `ps_obfuscate` if obfuscation is enabled, and implemented the toggle logic in the shell loop.


<img width="430" height="56" alt="image" src="https://github.com/user-attachments/assets/0347dc04-437b-449d-ade7-da92f2a5178d" />