### PR TITLE
Fixing KRB5CCNAME custom location ticket

### DIFF
--- a/evil_winrm_py/evil_winrm_py.py
+++ b/evil_winrm_py/evil_winrm_py.py
@@ -1493,6 +1493,15 @@ def main():
             if not args.password:
                 args.password = None
 
+        # When using Kerberos with cached tickets (KRB5CCNAME), don't pass username to WSMan
+        # This allows spnego to auto-detect the principal from the credential cache
+        # Without this, spnego fails to find the principal when KRB5CCNAME points to a custom location
+        kerberos_user = args.user
+        if auth == "kerberos" and args.no_pass and os.environ.get('KRB5CCNAME'):
+            log.info("Detected KRB5CCNAME environment variable, letting spnego auto-detect principal from cache")
+            kerberos_user = None
+            username = args.user if args.user else username
+
         if username:
             log.info(
                 "[*] Connecting to '{}:{}' as '{}'"
@@ -1511,7 +1520,7 @@ def main():
             port=args.port,
             auth=auth,
             encryption=encryption,
-            username=args.user,
+            username=kerberos_user,
             password=args.password,
             ssl=args.ssl,
             cert_validation=False,


### PR DESCRIPTION
# Fix: Support KRB5CCNAME environment variable for custom Kerberos credential cache locations

## Problem

When using Kerberos authentication with a custom credential cache location (via `KRB5CCNAME` environment variable), evil-winrm-py fails to authenticate even though the ticket is valid and other Kerberos tools (like `klist`) can read it successfully.

### Error Message
```
[-] Getting GSSAPI credential
[-] No credentials were supplied, or the credentials were unavailable or inaccessible
```

### Current Workaround
Users must copy their Kerberos ticket to the default location (`/tmp/krb5cc_<UID>`) and unset `KRB5CCNAME` for authentication to work.

## Root Cause

When a username is provided with Kerberos authentication (`-u username --no-pass -k`), evil-winrm-py passes this username to the underlying `spnego` library. The `spnego` library then attempts to find that specific principal in the credential cache. However, when `KRB5CCNAME` points to a custom location, `spnego` fails to properly locate the credential cache when searching for a specific principal, resulting in authentication failure.

From the debug logs:
```
SpnegoError (7): Major (458752): No credentials were supplied, or the credentials were unavailable or inaccessible,
Minor (2529639053): Can't find client principal monitoring_svc@NANOCORP.HTB in cache collection
```

## Solution

This PR modifies the authentication logic to detect when all of the following conditions are met:
1. Kerberos authentication is enabled (`--kerberos` or `-k`)
2. Password-less authentication is requested (`--no-pass`)
3. `KRB5CCNAME` environment variable is set

When these conditions are met, the code passes `None` as the username to `WSManEWP`, allowing the `spnego` library to auto-detect the principal from the credential cache instead of searching for a specific principal name.

### Code Changes

**File:** `evil_winrm_py/evil_winrm_py.py`

Added logic to detect `KRB5CCNAME` and conditionally pass username to WSMan:

```python
# When using Kerberos with cached tickets (KRB5CCNAME), don't pass username to WSMan
# This allows spnego to auto-detect the principal from the credential cache
# Without this, spnego fails to find the principal when KRB5CCNAME points to a custom location
kerberos_user = args.user
if auth == "kerberos" and args.no_pass and os.environ.get('KRB5CCNAME'):
    log.info("Detected KRB5CCNAME environment variable, letting spnego auto-detect principal from cache")
    kerberos_user = None
    username = args.user if args.user else username
```

## Testing

### Before Fix
```bash
export KRB5CCNAME=FILE:/path/to/custom/ticket.ccache
klist  # Shows valid ticket
evil-winrm-py -i dc01.example.com -u username --no-pass -k --ssl --port 5986
# ❌ Fails with "No credentials were supplied"
```

### After Fix
```bash
export KRB5CCNAME=/path/to/custom/ticket.ccache
klist  # Shows valid ticket
evil-winrm-py -i dc01.example.com -u username --no-pass -k --ssl --port 5986
# ✅ Connects successfully
```

### Alternate Usage (without username)
```bash
export KRB5CCNAME=/path/to/custom/ticket.ccache
evil-winrm-py -i dc01.example.com --no-pass -k --ssl --port 5986
```

## Compatibility

- **Non-breaking change**: Existing workflows are not affected
- **Default behavior unchanged**: When `KRB5CCNAME` is not set, behavior remains the same
- **Password-based Kerberos**: Unaffected - continues to work as before
- **Other auth methods**: No changes to NTLM, certificate, or other authentication methods

## Additional Notes

- Works with both relative and absolute paths in `KRB5CCNAME`
- Debug logging includes a message when the workaround is activated
- The `KRB5_CONFIG` environment variable continues to work as expected

## Documentation Updates

The existing documentation in `docs/usage.md` already mentions using `KRB5CCNAME`, so no documentation changes are needed. This fix simply makes that documented feature work correctly.

