### PR TITLE
Add support for JEA configurations

### DIFF
--- a/evil_winrm_py/evil_winrm_py.py
+++ b/evil_winrm_py/evil_winrm_py.py
@@ -149,24 +149,29 @@ class DelayedKeyboardInterrupt:
             self.old_handler(*self.signal_received)
 
 
-def run_ps_cmd(r_pool: RunspacePool, command: str) -> tuple[str, list, bool]:
+def run_ps_cmd(r_pool: RunspacePool, command: str, jea_mode: bool = False) -> tuple[str, list, bool]:
     """Runs a PowerShell command and returns the output, streams, and error status."""
     log.info("Executing command: {}".format(command))
     ps = PowerShell(r_pool)
-    ps.add_cmdlet("Invoke-Expression").add_parameter("Command", command)
-    ps.add_cmdlet("Out-String").add_parameter("Stream")
+    if jea_mode:
+        # JEA sessions don't expose Invoke-Expression; use add_script() directly
+        ps.add_script(command)
+    else:
+        ps.add_cmdlet("Invoke-Expression").add_parameter("Command", command)
+        ps.add_cmdlet("Out-String").add_parameter("Stream")
     ps.invoke()
     return "\n".join(ps.output), ps.streams, ps.had_errors
 
 
-def get_prompt(r_pool: RunspacePool) -> str:
+def get_prompt(r_pool: RunspacePool, configuration_name: str = None) -> str:
     """Returns the prompt string for the interactive shell."""
     output, streams, had_errors = run_ps_cmd(
-        r_pool, "$pwd.Path"
+        r_pool, "$pwd.Path", jea_mode=configuration_name is not None
     )  # Get current working directory
+    jea_tag = f" {MAGENTA}[JEA:{configuration_name}]{RESET}" if configuration_name else ""
     if not had_errors:
-        return f"{RED}evil-winrm-py{RESET} {YELLOW}{BOLD}PS{RESET} {output}> "
-    return "PS ?> "  # Fallback prompt
+        return f"{RED}evil-winrm-py{RESET}{jea_tag} {YELLOW}{BOLD}PS{RESET} {output}> "
+    return f"JEA:{configuration_name}> " if configuration_name else "PS ?> "  # Fallback prompt
 
 
 def show_menu() -> None:
@@ -1155,7 +1160,7 @@ def run_exe(r_pool: RunspacePool, local_path: str, args: str = "") -> None:
             ps.stop()
 
 
-def interactive_shell(r_pool: RunspacePool) -> None:
+def interactive_shell(r_pool: RunspacePool, configuration_name: str = None) -> None:
     """Runs the interactive pseudo-shell."""
     log.info("Starting interactive PowerShell session...")
 
@@ -1181,7 +1186,7 @@ def interactive_shell(r_pool: RunspacePool) -> None:
     while True:
         try:
             try:
-                prompt_text = ANSI(get_prompt(r_pool))
+                prompt_text = ANSI(get_prompt(r_pool, configuration_name))
             except (KeyboardInterrupt, EOFError):
                 return
             command = prompt_session.prompt(
@@ -1388,8 +1393,12 @@ def interactive_shell(r_pool: RunspacePool) -> None:
             else:
                 try:
                     ps = PowerShell(r_pool)
-                    ps.add_cmdlet("Invoke-Expression").add_parameter("Command", command)
-                    ps.add_cmdlet("Out-String").add_parameter("Stream")
+                    if configuration_name:
+                        # JEA: Invoke-Expression not available, use add_script() directly
+                        ps.add_script(command)
+                    else:
+                        ps.add_cmdlet("Invoke-Expression").add_parameter("Command", command)
+                        ps.add_cmdlet("Out-String").add_parameter("Stream")
                     ps.begin_invoke()
                     log.info("Executing command: {}".format(command))
 
@@ -1399,10 +1408,10 @@ def interactive_shell(r_pool: RunspacePool) -> None:
                             ps.poll_invoke()
                         output = ps.output
                         for line in output[cursor:]:
-                            print(line)
+                            print(str(line))
                         cursor = len(output)
                     log.info("Command execution completed.")
-                    log.info("Output: {}".format("\n".join(output)))
+                    log.info("Output: {}".format("\n".join(str(l) for l in output)))
 
                     if ps.streams.error:
                         for error in ps.streams.error:
@@ -1482,6 +1491,12 @@ def main():
         "--no-pass", action="store_true", help="do not prompt for password"
     )
     parser.add_argument("--ssl", action="store_true", help="use ssl")
+    parser.add_argument(
+        "-c",
+        "--configuration-name",
+        default=None,
+        help="JEA configuration name (PSSessionConfiguration endpoint)",
+    )
     parser.add_argument("--log", action="store_true", help="log session to file")
     parser.add_argument("--debug", action="store_true", help="enable debug logging")
     parser.add_argument("--no-colors", action="store_true", help="disable colors")
@@ -1640,8 +1655,11 @@ def main():
             certificate_pem=args.cert_pem,
             user_agent=args.ua,
         ) as wsman:
-            with RunspacePool(wsman) as r_pool:
-                interactive_shell(r_pool)
+            runspace_kwargs = {}
+            if args.configuration_name:
+                runspace_kwargs["configuration_name"] = args.configuration_name
+            with RunspacePool(wsman, **runspace_kwargs) as r_pool:
+                interactive_shell(r_pool, args.configuration_name)
     except (KeyboardInterrupt, EOFError):
         sys.exit(0)
     except WinRMTransportError as wte:


### PR DESCRIPTION
This pull request adds support for Just Enough Administration (JEA) session configuration in the `evil_winrm_py` interactive shell. The changes allow users to specify a JEA configuration endpoint, and adapt command execution and prompt rendering to work correctly in JEA-restricted environments.

JEA session support:

* Added a `--configuration-name` (`-c`) command-line argument to specify a JEA (PSSessionConfiguration) endpoint when connecting.
* Updated `main()` to pass the `configuration_name` argument to both `RunspacePool` and `interactive_shell`, enabling JEA mode when specified.

Command execution and prompt adaptation for JEA:

* Modified `run_ps_cmd` and interactive shell command execution to use `add_script()` instead of `Invoke-Expression` when in JEA mode, since `Invoke-Expression` is not available in JEA sessions. [[1]](diffhunk://#diff-bf104e58976c88a3dc55cd65710696f2a3c04be1ad9f54665772cefa521eb5eeL152-R174) [[2]](diffhunk://#diff-bf104e58976c88a3dc55cd65710696f2a3c04be1ad9f54665772cefa521eb5eeR1396-R1399)
* Updated prompt rendering to display a JEA session tag with the configuration name, and adjusted fallback prompts for JEA mode. [[1]](diffhunk://#diff-bf104e58976c88a3dc55cd65710696f2a3c04be1ad9f54665772cefa521eb5eeL152-R174) [[2]](diffhunk://#diff-bf104e58976c88a3dc55cd65710696f2a3c04be1ad9f54665772cefa521eb5eeL1184-R1189)

Generalization for JEA-aware shell:

* Updated `interactive_shell` and its internal calls to accept and propagate the `configuration_name` parameter, ensuring all shell features are aware of JEA mode. [[1]](diffhunk://#diff-bf104e58976c88a3dc55cd65710696f2a3c04be1ad9f54665772cefa521eb5eeL1158-R1163) [[2]](diffhunk://#diff-bf104e58976c88a3dc55cd65710696f2a3c04be1ad9f54665772cefa521eb5eeL1184-R1189)

Output handling improvements:

* Ensured command output is consistently converted to string before printing and logging, improving reliability in both standard and JEA modes.